### PR TITLE
Allows CMake to cache internal state between builds

### DIFF
--- a/02_hash/CMakeLists.txt
+++ b/02_hash/CMakeLists.txt
@@ -19,13 +19,12 @@ enable_testing()
 FILE(GLOB InputTestFiles tests/*)
 
 add_library(hash STATIC hash.cc)
-target_include_directories(hash PRIVATE . )
+target_include_directories(hash PUBLIC . )
 
 add_executable(
     Tests
     ${InputTestFiles}
 )
-target_include_directories(Tests PRIVATE . )
 
 target_link_libraries(
     Tests

--- a/02_hash/test.sh
+++ b/02_hash/test.sh
@@ -5,11 +5,12 @@ FILEDIR=${1}
 [ -z ${FILEDIR} ] && printf "Nie podałeś folderu z plikami!\n" && exit 1
 
 rm -f hash.cc hash.h
-ln -s $FILEDIR/hash.cc hash.cc
-ln -s $FILEDIR/hash.h hash.h
+ln $FILEDIR/hash.cc hash.cc || exit 1
+ln $FILEDIR/hash.h hash.h || exit 1
 
-rm -rf build
-mkdir build
+[ ! -d "build" ] && mkdir build
+
 cd build
 cmake ..
+
 cmake --build .

--- a/02_hash/test.sh
+++ b/02_hash/test.sh
@@ -4,8 +4,9 @@ FILEDIR=${1}
 
 [ -z ${FILEDIR} ] && printf "Nie podałeś folderu z plikami!\n" && exit 1
 
-cp $FILEDIR/hash.cc .
-cp $FILEDIR/hash.h .
+rm -f hash.cc hash.h
+ln $FILEDIR/hash.cc hash.cc
+ln $FILEDIR/hash.h hash.h
 
 rm -rf build
 mkdir build

--- a/02_hash/test.sh
+++ b/02_hash/test.sh
@@ -5,8 +5,8 @@ FILEDIR=${1}
 [ -z ${FILEDIR} ] && printf "Nie podałeś folderu z plikami!\n" && exit 1
 
 rm -f hash.cc hash.h
-ln $FILEDIR/hash.cc hash.cc
-ln $FILEDIR/hash.h hash.h
+ln -s $FILEDIR/hash.cc hash.cc
+ln -s $FILEDIR/hash.h hash.h
 
 rm -rf build
 mkdir build

--- a/02_hash/test.sh
+++ b/02_hash/test.sh
@@ -5,6 +5,7 @@ FILEDIR=${1}
 [ -z ${FILEDIR} ] && printf "Nie podałeś folderu z plikami!\n" && exit 1
 
 rm -f hash.cc hash.h
+# Jeżeli tworzenie linków nie działa to należy podmienić poniższe linijki
 ln $FILEDIR/hash.cc hash.cc || exit 1
 ln $FILEDIR/hash.h hash.h || exit 1
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ _Testowanie_: Uruchamiamy plik `test.sh` w następujący sposób:
 
 `./test.sh ścieżka/do/folderu/z/rozwiązaniem`
 
+Skrypt usuwa pliki hash.cc i hash.h w swojej lokalizacji!  
+Podmienia je na linki stałe do faktycznych plików w innej lokalizacji. Dzięki temu CMake musi przebudować testy tylko jeśli zmienisz coś w `hash.h`
+
 Skrypt `test.sh` przygotuje plik wykonywalny o nazwie `Tests` i umieści go w katalogu `build`.
 Aby go uruchomić można wykonać:
 


### PR DESCRIPTION
Uprościłem delikatnie CMake
Największe zmiany są w test.sh. Poprzednio czyścił cache pomiędzy wywołaniami.
make używa timestampów na plikach (które cp nadpisuje) podmieniłem więc cp na tworzenie linków systemowych. Bardzo bym się zdziwił gdyby ma windows działało (na linuxie powinno działać bez zarzutu, możesz sprawdzić dla pewności).
Teraz testy przebudowują się tylko jeśli jest taka potrzeba, a nie przy każdym buildzie